### PR TITLE
Fixed module export type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "*": {
       "client": [
         "./dist/client.d.ts"
-      ],
+      ]
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
     },
     "./package.json": "./package.json"
   },
+  "typesVersions": {
+    "*": {
+      "client": [
+        "./dist/client.d.ts"
+      ],
+    }
+  },
   "scripts": {
     "build": "tsup",
     "lint": "tsc",


### PR DESCRIPTION
### What's been changed?

 - Updated `package.json`
	 - Added `typesVerions` property to correctly map `/client` export type definitions when not using `NodeNext` as their TypeScript module (Fixes #2 )